### PR TITLE
Fix finally usage

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -473,7 +473,9 @@ export class FluentClient {
     }
     if (!this.emitQueue.has(emitPromise)) {
       this.emitQueue.add(emitPromise);
-      emitPromise.finally(() => this.emitQueue.delete(emitPromise));
+      emitPromise
+        .finally(() => this.emitQueue.delete(emitPromise))
+        .catch(() => {});
     }
     return emitPromise;
   }
@@ -787,7 +789,7 @@ export class FluentClient {
 
     if (!chunk) {
       // Wait for the promise to resolve before resolving the deferred
-      writePromise.then(() => nextPacket.deferred.resolve()).catch(() => {});
+      writePromise.then(() => nextPacket.deferred.resolve());
     }
     return true;
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -787,7 +787,7 @@ export class FluentClient {
 
     if (!chunk) {
       // Wait for the promise to resolve before resolving the deferred
-      writePromise.then(() => nextPacket.deferred.resolve());
+      writePromise.then(() => nextPacket.deferred.resolve()).catch(() => {});
     }
     return true;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,8 +13,7 @@ export const awaitAtMost = <T>(
         }, timeout))
     ),
   ]);
-  racePromise.finally(() => (timeoutId ? clearTimeout(timeoutId) : undefined));
-  return racePromise;
+  return racePromise.finally(() => (timeoutId ? clearTimeout(timeoutId) : undefined));
 };
 
 export const awaitNextTick = (): Promise<void> => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,7 +13,9 @@ export const awaitAtMost = <T>(
         }, timeout))
     ),
   ]);
-  return racePromise.finally(() => (timeoutId ? clearTimeout(timeoutId) : undefined));
+  return racePromise.finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
 };
 
 export const awaitNextTick = (): Promise<void> => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,9 +13,12 @@ export const awaitAtMost = <T>(
         }, timeout))
     ),
   ]);
-  return racePromise.finally(() => {
-    if (timeoutId) clearTimeout(timeoutId);
-  });
+  racePromise
+    .finally(() => {
+      if (timeoutId) clearTimeout(timeoutId);
+    })
+    .catch(() => {});
+  return racePromise;
 };
 
 export const awaitNextTick = (): Promise<void> => {


### PR DESCRIPTION
`Promise.prototype.finally` will rethrow the error that caused it to be called in a new promise, so we need to make sure to either handle it, or pass it on to the caller to handle.

Fixes #28 